### PR TITLE
Default Input Path Quality of Life Improvement

### DIFF
--- a/Include/42.h
+++ b/Include/42.h
@@ -55,6 +55,9 @@ EXTERN long Nmatl;
 /* Number of geometric objects */
 EXTERN long Ngeom;
 
+#define STRINGIZE(x) #x
+#define STRINGIZE_VALUE_OF(x) STRINGIZE(x)
+
 EXTERN char InOutPath[80];
 EXTERN char ModelPath[80];
 EXTERN char CmdFileName[80];

--- a/Kit/Include/iokit.h
+++ b/Kit/Include/iokit.h
@@ -31,6 +31,8 @@
 #include <fcntl.h>
 #ifdef _WIN32
    #include <winsock2.h>
+   extern char *_pgmptr;
+   #define OS_SEP '\\'
 #else
    #include <sys/socket.h>
    #include <netinet/in.h>
@@ -38,6 +40,7 @@
    #include <netdb.h>
    /* Finesse winsock SOCKET datatype */
    #define SOCKET int
+   #define OS_SEP '/'
 #endif
 /* #include <sys/un.h> */
 
@@ -48,6 +51,10 @@ int FileToString(const char *file_name, char **result_string,
 
 SOCKET InitSocketServer(int Port, int AllowBlocking);
 SOCKET InitSocketClient(const char *hostname, int Port, int AllowBlocking);
+
+void SplitPath(char *path_file, char **path, char **file);
+void GetExecutablePath(char *path, size_t bufsize);
+void AddTrailingSlash(char *path);
 
 /*
 ** #ifdef __cplusplus

--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,12 @@ GMSECFLAG =
 RBTFLAG = 
 #RBTFLAG = -D _ENABLE_RBT_
 
+DEFAULT_CASE_PATH = 
+#DEFAULT_CASE_PATH = -D _DEFAULT_CASE_PATH_=./InOut
+
+DEFAULT_MODEL_PATH = 
+#DEFAULT_MODEL_PATH = -D _DEFAULT_MODEL_PATH_=./Model
+
 ifeq ($(strip $(GMSECFLAG)),)
    GMSECDIR =
    GMSECINC =
@@ -243,7 +249,7 @@ $(OBJ)AppWriteToSocket.o $(OBJ)AppReadFromSocket.o $(OBJ)AppWriteToFile.o
 #ANSIFLAGS = -Wstrict-prototypes -pedantic -ansi -Werror
 ANSIFLAGS =
 
-CFLAGS = -fpic -Wall -Wshadow -Wno-deprecated $(XWARN) -g  $(ANSIFLAGS) $(GLINC) $(CINC) -I $(INC) -I $(KITINC) -I $(KITSRC) -I $(RBTSRC) $(GMSECINC) -O0 $(ARCHFLAG) $(GUIFLAG) $(GUI_LIB) $(SHADERFLAG) $(CFDFLAG) $(FFTBFLAG) $(GSFCFLAG) $(GMSECFLAG) $(STANDALONEFLAG) $(RBTFLAG)
+CFLAGS = -fpic -Wall -Wshadow -Wno-deprecated $(XWARN) -g  $(ANSIFLAGS) $(GLINC) $(CINC) -I $(INC) -I $(KITINC) -I $(KITSRC) -I $(RBTSRC) $(GMSECINC) -O0 $(ARCHFLAG) $(GUIFLAG) $(GUI_LIB) $(SHADERFLAG) $(CFDFLAG) $(FFTBFLAG) $(GSFCFLAG) $(GMSECFLAG) $(STANDALONEFLAG) $(RBTFLAG) $(DEFAULT_CASE_PATH) $(DEFAULT_MODEL_PATH)
 
 
 ##########################  Rules to link 42  #############################

--- a/Source/42init.c
+++ b/Source/42init.c
@@ -4368,8 +4368,41 @@ void InitSim(int argc, char **argv)
          if (argc > 1) sprintf(InOutPath,"../../GSFC/RBT/%s/",argv[1]);
          if (argc > 2) sprintf(ModelPath,"../../GSFC/RBT/%s/",argv[2]);
       #else
-         sprintf(InOutPath,"./InOut/");
-         sprintf(ModelPath,"./Model/");
+         char *exec_name, *exec_dir, *exec_path;
+         exec_path = (char *)malloc(FILENAME_MAX);
+
+         GetExecutablePath(exec_path, FILENAME_MAX);
+         SplitPath(exec_path, &exec_dir, &exec_name);
+
+         if (strlen(exec_dir) == 0) {
+           printf("Error finding executable's containing folder. Exiting.");
+           exit(EXIT_FAILURE);
+         }
+
+         AddTrailingSlash(exec_dir);
+
+#ifndef _DEFAULT_CASE_PATH_
+         strcpy(InOutPath, exec_dir);
+         strcat(InOutPath, "examples/InOut");
+#else
+         sprintf(InOutPath, STRINGIZE_VALUE_OF(_DEFAULT_CASE_PATH_));
+#endif
+
+         AddTrailingSlash((char *)InOutPath);
+
+#ifndef _DEFAULT_MODEL_PATH_
+         strcpy(ModelPath, exec_dir);
+         strcat(ModelPath, "Model");
+#else
+         sprintf(ModelPath, STRINGIZE_VALUE_OF(_DEFAULT_MODEL_PATH_));
+#endif
+
+         AddTrailingSlash((char *)ModelPath);
+
+         free(exec_name);
+         free(exec_dir);
+         free(exec_path);
+
          if (argc > 1) sprintf(InOutPath,"./%s/",argv[1]);
          if (argc > 2) sprintf(ModelPath,"./%s/",argv[2]);
       #endif


### PR DESCRIPTION
Looks for input files relative to the executable path instead of cwd. Since all examples in this fork have been moved to `examples/`, the default behavior is to set `InOutPath` to `/path/to/42/examples/InOut/`.

Still retains argument functionality; i.e. argv[1] and argv[2] can still be used to set the input file paths to arbitrary directories. Further, the original functionality of defaulting to looking at cwd can be achieved by accordingly setting the `DEFAULT_CASE_PATH`/`DEFAULT_MODEL_PATH` variables in the makefile.

Functionality when compiling with the `RBTFLAG` is unaffected.

Also adds a couple helper functions to iokit.